### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/181/653/421181653.geojson
+++ b/data/421/181/653/421181653.geojson
@@ -303,6 +303,9 @@
     },
     "wof:country":"PF",
     "wof:created":1459009302,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37422f1d1c7602789fc00c0c70a0d07f",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         }
     ],
     "wof:id":421181653,
-    "wof:lastmodified":1566677717,
+    "wof:lastmodified":1582343575,
     "wof:name":"Arue",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.