### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/134/417/196/7/1344171967.geojson
+++ b/data/134/417/196/7/1344171967.geojson
@@ -29,8 +29,26 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:afr_x_preferred":[
+        "Tetiaroa"
+    ],
     "name:ara_x_preferred":[
         "\u062a\u064a\u0634\u0627\u0631\u0648\u0627"
+    ],
+    "name:aze_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:bel_x_preferred":[
+        "\u0422\u044d\u0446\u0456\u0430\u0440\u043e\u0430"
+    ],
+    "name:cat_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:ceb_x_preferred":[
+        "Atoll Tetiaroa"
+    ],
+    "name:dan_x_preferred":[
+        "Tetiaroa"
     ],
     "name:deu_x_preferred":[
         "Tetiaroa"
@@ -41,11 +59,62 @@
     "name:eng_x_variant":[
         "Titiaroa"
     ],
+    "name:epo_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:fin_x_preferred":[
+        "Tetiaroa"
+    ],
     "name:fra_x_preferred":[
         "Tetiaroa"
     ],
+    "name:glg_x_preferred":[
+        "Atol Tetiaroa"
+    ],
+    "name:gsw_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:hun_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:ita_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c6\u30c6\u30a3\u30a2\u30ed\u30a2\u5cf6"
+    ],
+    "name:lit_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0422\u0435\u0442\u0438\u0430\u0440\u043e\u0430"
+    ],
+    "name:nld_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:nob_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:pol_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:por_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:rus_x_preferred":[
+        "\u0422\u0435\u0442\u0438\u0430\u0440\u043e\u0430"
+    ],
     "name:spa_x_preferred":[
         "Tetiaroa"
+    ],
+    "name:swe_x_preferred":[
+        "Tetiaroa"
+    ],
+    "name:tah_x_preferred":[
+        "Teti\u2019aroa"
+    ],
+    "name:zho_x_preferred":[
+        "\u6cf0\u8482\u4e9e\u7f85\u963f\u74b0\u7901"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[],
@@ -65,7 +134,7 @@
         }
     ],
     "wof:id":1344171967,
-    "wof:lastmodified":1662673265,
+    "wof:lastmodified":1690850812,
     "wof:name":"Tetiaroa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/168/283/421168283.geojson
+++ b/data/421/168/283/421168283.geojson
@@ -212,6 +212,9 @@
     "name:ron_x_preferred":[
         "Uturoa"
     ],
+    "name:rus_x_preferred":[
+        "\u0423\u0442\u0443\u0440\u043e\u0430"
+    ],
     "name:scn_x_preferred":[
         "Uturoa"
     ],
@@ -314,7 +317,7 @@
         }
     ],
     "wof:id":421168283,
-    "wof:lastmodified":1566677715,
+    "wof:lastmodified":1690850814,
     "wof:name":"Uturoa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/175/359/421175359.geojson
+++ b/data/421/175/359/421175359.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u064a\u062a\u0627\u0628\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0627\u064a\u062a\u0627\u0628\u0649"
+    ],
     "name:ben_x_preferred":[
         "\u09ad\u09bf\u099f\u09be\u09aa\u09c7"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:ceb_x_preferred":[
         "Vaitape"
+    ],
+    "name:che_x_preferred":[
+        "\u0412\u0430\u0439\u0442\u0430\u043f\u0435"
     ],
     "name:dan_x_preferred":[
         "Vaitape"
@@ -180,7 +186,7 @@
         }
     ],
     "wof:id":421175359,
-    "wof:lastmodified":1566677717,
+    "wof:lastmodified":1690850817,
     "wof:name":"Vaitape",
     "wof:parent_id":85676731,
     "wof:placetype":"locality",

--- a/data/421/176/587/421176587.geojson
+++ b/data/421/176/587/421176587.geojson
@@ -66,6 +66,9 @@
     "name:ces_x_preferred":[
         "Papeete"
     ],
+    "name:che_x_preferred":[
+        "\u041f\u0430\u043f\u0435\u044d\u0442\u0435"
+    ],
     "name:cos_x_preferred":[
         "Papeete"
     ],
@@ -82,6 +85,9 @@
         "\u03a0\u03b1\u03c0\u03b5\u03ad\u03c4\u03b5"
     ],
     "name:ell_x_variant":[
+        "Papeete"
+    ],
+    "name:eml_x_preferred":[
         "Papeete"
     ],
     "name:eng_x_preferred":[
@@ -137,6 +143,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aaa\u0aaa\u0ac0\u0a9f\u0ac7"
+    ],
+    "name:haw_x_preferred":[
+        "Pape\u02bbete"
     ],
     "name:hbs_x_preferred":[
         "Papeete"
@@ -234,6 +243,9 @@
     "name:mlg_x_preferred":[
         "Papeete"
     ],
+    "name:mlt_x_preferred":[
+        "Papeete"
+    ],
     "name:msa_x_preferred":[
         "Papeete"
     ],
@@ -261,6 +273,9 @@
     "name:oci_x_preferred":[
         "Papeete"
     ],
+    "name:oci_x_variant":[
+        "Pape\u2019ete"
+    ],
     "name:oss_x_preferred":[
         "\u041f\u0430\u043f\u0435\u044d\u0442\u0435"
     ],
@@ -287,6 +302,9 @@
     ],
     "name:prg_x_preferred":[
         "Papeete"
+    ],
+    "name:pus_x_preferred":[
+        "\u067e\u0627\u067e\u06cc\u062a"
     ],
     "name:rgn_x_preferred":[
         "Papeete"
@@ -345,6 +363,9 @@
     "name:tel_x_preferred":[
         "\u0c2a\u0c3e\u0c2a\u0c40\u0c1f\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u041f\u0430\u043f\u0435\u044d\u0442\u0435"
+    ],
     "name:tha_x_preferred":[
         "\u0e1b\u0e32\u0e40\u0e1b\u0e40\u0e2d\u0e40\u0e15"
     ],
@@ -383,6 +404,9 @@
     ],
     "name:wol_x_preferred":[
         "Papeete"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5e15\u76ae\u63d0"
     ],
     "name:yue_x_preferred":[
         "\u5df4\u6bd4\u63d0"
@@ -529,7 +553,7 @@
         }
     ],
     "wof:id":421176587,
-    "wof:lastmodified":1566677718,
+    "wof:lastmodified":1690850819,
     "wof:name":"Papeete",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/421/181/653/421181653.geojson
+++ b/data/421/181/653/421181653.geojson
@@ -32,6 +32,9 @@
     "name:bar_x_preferred":[
         "Arue"
     ],
+    "name:bre_x_preferred":[
+        "Arue"
+    ],
     "name:cat_x_preferred":[
         "Arue"
     ],
@@ -64,6 +67,9 @@
     ],
     "name:fao_x_preferred":[
         "Arue"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0631\u0648"
     ],
     "name:fin_x_preferred":[
         "Arue"
@@ -118,6 +124,9 @@
     ],
     "name:jam_x_preferred":[
         "Arue"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a2\u30eb\u30a8"
     ],
     "name:kab_x_preferred":[
         "Arue"
@@ -233,6 +242,9 @@
     "name:tur_x_preferred":[
         "Arue"
     ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0440\u0443\u0435"
+    ],
     "name:und_x_variant":[
         "Arve"
     ],
@@ -317,7 +329,7 @@
         }
     ],
     "wof:id":421181653,
-    "wof:lastmodified":1582343575,
+    "wof:lastmodified":1690850817,
     "wof:name":"Arue",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/421/181/657/421181657.geojson
+++ b/data/421/181/657/421181657.geojson
@@ -23,6 +23,9 @@
     "name:ceb_x_preferred":[
         "Pueu"
     ],
+    "name:deu_x_preferred":[
+        "P\u016beu"
+    ],
     "name:eng_x_preferred":[
         "Pueu"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":421181657,
-    "wof:lastmodified":1566677717,
+    "wof:lastmodified":1690850817,
     "wof:name":"Pueu",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/421/181/661/421181661.geojson
+++ b/data/421/181/661/421181661.geojson
@@ -122,6 +122,9 @@
     "name:jam_x_preferred":[
         "Paea"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d1\u30a8\u30a2"
+    ],
     "name:kab_x_preferred":[
         "Paea"
     ],
@@ -304,7 +307,7 @@
         }
     ],
     "wof:id":421181661,
-    "wof:lastmodified":1566677717,
+    "wof:lastmodified":1690850816,
     "wof:name":"Paea",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/421/184/469/421184469.geojson
+++ b/data/421/184/469/421184469.geojson
@@ -29,6 +29,9 @@
     "name:fra_x_preferred":[
         "Hauti"
     ],
+    "name:ltz_x_preferred":[
+        "Hauti"
+    ],
     "name:spa_x_preferred":[
         "Hauti"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421184469,
-    "wof:lastmodified":1566677718,
+    "wof:lastmodified":1690850818,
     "wof:name":"Hauti",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/187/879/421187879.geojson
+++ b/data/421/187/879/421187879.geojson
@@ -35,6 +35,9 @@
     "name:bar_x_preferred":[
         "Tahaa"
     ],
+    "name:bel_x_preferred":[
+        "\u0422\u0430\u0445\u0430\u0430"
+    ],
     "name:bre_x_preferred":[
         "Tahaa"
     ],
@@ -100,6 +103,9 @@
     ],
     "name:gsw_x_preferred":[
         "Tahaa"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d8\u05d4\u05d0\u05d4\u05d0"
     ],
     "name:hrv_x_preferred":[
         "Tahaa"
@@ -317,7 +323,7 @@
         }
     ],
     "wof:id":421187879,
-    "wof:lastmodified":1566677716,
+    "wof:lastmodified":1690850816,
     "wof:name":"Vaitoare",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/193/185/421193185.geojson
+++ b/data/421/193/185/421193185.geojson
@@ -20,11 +20,20 @@
     "name:afr_x_preferred":[
         "Teahupoo"
     ],
+    "name:ara_x_preferred":[
+        "\u062a\u064a\u0647\u0648\u0628\u0648"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0435\u0430\u0445\u0443\u043f\u043e"
     ],
+    "name:cat_x_preferred":[
+        "Teahupo'o"
+    ],
     "name:ceb_x_preferred":[
         "Teahupoo"
+    ],
+    "name:ces_x_preferred":[
+        "Teahupo'o"
     ],
     "name:deu_x_preferred":[
         "Teahupoo"
@@ -34,6 +43,15 @@
     ],
     "name:fra_x_preferred":[
         "Teahupoo"
+    ],
+    "name:gle_x_preferred":[
+        "Teahupoo"
+    ],
+    "name:ita_x_preferred":[
+        "Teahupo'o"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30c6\u30a2\u30d5\u30dd\u30aa"
     ],
     "name:lit_x_preferred":[
         "Teahupoo"
@@ -53,6 +71,9 @@
     "name:rus_x_preferred":[
         "\u0422\u0435\u0430\u0445\u0443\u043f\u043e\u043e"
     ],
+    "name:slk_x_preferred":[
+        "Teahupo'o"
+    ],
     "name:spa_x_preferred":[
         "Teahupo'o"
     ],
@@ -61,6 +82,9 @@
     ],
     "name:und_x_variant":[
         "Teahupu"
+    ],
+    "name:zho_x_preferred":[
+        "\u7279\u4e4e\u666e\u6b50"
     ],
     "qs:gn_country":"PF",
     "qs:gn_fcode":"PPL",
@@ -106,7 +130,7 @@
         }
     ],
     "wof:id":421193185,
-    "wof:lastmodified":1566677715,
+    "wof:lastmodified":1690850814,
     "wof:name":"Teahupoo",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/421/197/829/421197829.geojson
+++ b/data/421/197/829/421197829.geojson
@@ -32,6 +32,9 @@
     "name:deu_x_preferred":[
         "Pauschaltarif"
     ],
+    "name:deu_x_variant":[
+        "Tarifsystem"
+    ],
     "name:eng_x_preferred":[
         "Fare"
     ],
@@ -50,11 +53,20 @@
     "name:gle_x_preferred":[
         "t\u00e1ille"
     ],
+    "name:ita_x_preferred":[
+        "tariffa"
+    ],
     "name:jpn_x_preferred":[
         "\u904b\u8cc3"
     ],
     "name:kor_x_preferred":[
         "\uc6b4\uc784"
+    ],
+    "name:ltz_x_preferred":[
+        "Tarifsystem"
+    ],
+    "name:nld_x_preferred":[
+        "tarief"
     ],
     "name:por_x_preferred":[
         "Tarifa"
@@ -62,11 +74,17 @@
     "name:por_x_variant":[
         "tarifa"
     ],
+    "name:slv_x_preferred":[
+        "voznina"
+    ],
     "name:spa_x_preferred":[
         "Tarifa"
     ],
     "name:spa_x_variant":[
         "tarifa"
+    ],
+    "name:swa_x_preferred":[
+        "Nauli"
     ],
     "name:und_x_variant":[
         "Owharre"
@@ -124,7 +142,7 @@
         }
     ],
     "wof:id":421197829,
-    "wof:lastmodified":1566677718,
+    "wof:lastmodified":1690850818,
     "wof:name":"Fare",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/202/787/421202787.geojson
+++ b/data/421/202/787/421202787.geojson
@@ -17,22 +17,112 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:bre_x_preferred":[
+        "Tautira"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0430\u0443\u0442\u0438\u0440\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Tautira"
+    ],
     "name:ceb_x_preferred":[
+        "Tautira"
+    ],
+    "name:ces_x_preferred":[
+        "Tautira"
+    ],
+    "name:cos_x_preferred":[
+        "Tautira"
+    ],
+    "name:cym_x_preferred":[
+        "Tautira"
+    ],
+    "name:dan_x_preferred":[
+        "Tautira"
+    ],
+    "name:deu_x_preferred":[
         "Tautira"
     ],
     "name:eng_x_preferred":[
         "Tautira"
     ],
+    "name:est_x_preferred":[
+        "Tautira"
+    ],
+    "name:fin_x_preferred":[
+        "Tautira"
+    ],
     "name:fra_x_preferred":[
+        "Tautira"
+    ],
+    "name:gle_x_preferred":[
+        "Tautira"
+    ],
+    "name:glg_x_preferred":[
+        "Tautira"
+    ],
+    "name:hrv_x_preferred":[
+        "Tautira"
+    ],
+    "name:hun_x_preferred":[
+        "Tautira"
+    ],
+    "name:ind_x_preferred":[
+        "Tautira"
+    ],
+    "name:ita_x_preferred":[
+        "Tautira"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30bf\u30a6\u30c6\u30a3\u30e9"
+    ],
+    "name:lav_x_preferred":[
+        "Tautira"
+    ],
+    "name:lit_x_preferred":[
+        "Tautira"
+    ],
+    "name:ltz_x_preferred":[
         "Tautira"
     ],
     "name:nld_x_preferred":[
         "Tautira"
     ],
+    "name:nrm_x_preferred":[
+        "Tautira"
+    ],
+    "name:oci_x_preferred":[
+        "Tautira"
+    ],
+    "name:pol_x_preferred":[
+        "Tautira"
+    ],
+    "name:por_x_preferred":[
+        "Tautira"
+    ],
+    "name:roh_x_preferred":[
+        "Tautira"
+    ],
+    "name:ron_x_preferred":[
+        "Tautira"
+    ],
+    "name:slk_x_preferred":[
+        "Tautira"
+    ],
+    "name:slv_x_preferred":[
+        "Tautira"
+    ],
     "name:spa_x_preferred":[
+        "Tautira"
+    ],
+    "name:swe_x_preferred":[
+        "Tautira"
+    ],
+    "name:tah_x_preferred":[
+        "Tautira"
+    ],
+    "name:tur_x_preferred":[
         "Tautira"
     ],
     "name:und_x_variant":[
@@ -80,7 +170,7 @@
         }
     ],
     "wof:id":421202787,
-    "wof:lastmodified":1566677716,
+    "wof:lastmodified":1690850815,
     "wof:name":"Tautira",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/202/791/421202791.geojson
+++ b/data/421/202/791/421202791.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "Pirae"
     ],
+    "name:ara_x_preferred":[
+        "\u0628\u064a\u0631\u0627\u064a"
+    ],
     "name:arg_x_preferred":[
         "Pirae"
     ],
@@ -36,6 +39,9 @@
         "Pirae"
     ],
     "name:cat_x_preferred":[
+        "Pirae"
+    ],
+    "name:ceb_x_preferred":[
         "Pirae"
     ],
     "name:ces_x_preferred":[
@@ -313,7 +319,7 @@
         }
     ],
     "wof:id":421202791,
-    "wof:lastmodified":1566677716,
+    "wof:lastmodified":1690850815,
     "wof:name":"Pirae",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/421/202/793/421202793.geojson
+++ b/data/421/202/793/421202793.geojson
@@ -260,6 +260,9 @@
     "name:wol_x_preferred":[
         "Mahina"
     ],
+    "name:zho_x_preferred":[
+        "\u9a6c\u5e0c\u7eb3"
+    ],
     "name:zul_x_preferred":[
         "Mahina"
     ],
@@ -306,7 +309,7 @@
         }
     ],
     "wof:id":421202793,
-    "wof:lastmodified":1566677716,
+    "wof:lastmodified":1690850815,
     "wof:name":"Mahina",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/856/767/27/85676727.geojson
+++ b/data/856/767/27/85676727.geojson
@@ -41,6 +41,9 @@
     "name:cat_x_variant":[
         "illes del Vent"
     ],
+    "name:ceb_x_preferred":[
+        "\u00celes du Vent"
+    ],
     "name:ces_x_preferred":[
         "N\u00e1v\u011btrn\u00e9 ostrovy"
     ],
@@ -134,6 +137,9 @@
     "name:nor_x_preferred":[
         "\u00celes du Vent"
     ],
+    "name:oci_x_preferred":[
+        "Illas del Vent"
+    ],
     "name:pol_x_preferred":[
         "Wyspy Na Wietrze"
     ],
@@ -160,6 +166,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bb5\u0bbf\u0ba3\u0bcd\u0b9f\u0bcd\u0bb5\u0bb0\u0bcd\u0b9f\u0bcd \u0b87\u0bb8\u0bcd\u0bb2\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd\u0bb8\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb5\u0bbf\u0ba3\u0bcd\u0b9f\u0bcd\u0bb5\u0bb0\u0bcd\u0b9f\u0bcd  \u0b87\u0bb8\u0bcd\u0bb2\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd\u0bb8\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c35\u0c3f\u0c02\u0c21\u0c4d\u0c35\u0c30\u0c4d\u0c21\u0c4d \u0c26\u0c40\u0c35\u0c41\u0c32\u0c41"
@@ -320,7 +329,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1636500406,
+    "wof:lastmodified":1690850813,
     "wof:name":"Windward Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",

--- a/data/856/767/31/85676731.geojson
+++ b/data/856/767/31/85676731.geojson
@@ -59,6 +59,9 @@
     "name:eus_x_preferred":[
         "Haizebearen Uharteak"
     ],
+    "name:eus_x_variant":[
+        "Haizebearen uharteak"
+    ],
     "name:fas_x_preferred":[
         "\u062c\u0632\u0627\u06cc\u0631 \u0628\u0627\u062f\u067e\u0646\u0627\u0647"
     ],
@@ -139,6 +142,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bb2\u0bc0\u0bb5\u0bcd\u0bb0\u0bcd\u0b9f\u0bc1 \u0b87\u0bb8\u0bcd\u0bb2\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd\u0bb8\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb2\u0bc0\u0bb5\u0bcd\u0bb0\u0bcd\u0b9f\u0bc1  \u0b87\u0bb8\u0bcd\u0bb2\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd\u0bb8\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c32\u0c40\u0c35\u0c3e\u0c30\u0c4d\u0c21\u0c4d \u0c26\u0c40\u0c35\u0c41\u0c32\u0c41"
@@ -296,7 +302,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1636500406,
+    "wof:lastmodified":1690850813,
     "wof:name":"Leeward Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",

--- a/data/856/767/37/85676737.geojson
+++ b/data/856/767/37/85676737.geojson
@@ -41,11 +41,20 @@
     "name:ceb_x_preferred":[
         "\u00celes Tuamotu-Gambier"
     ],
+    "name:ceb_x_variant":[
+        "Iles Tuamotu-Gambier"
+    ],
     "name:dan_x_preferred":[
         "\u00celes Tuamotu-Gambier"
     ],
+    "name:dan_x_variant":[
+        "Iles Tuamotu-Gambier"
+    ],
     "name:deu_x_preferred":[
         "\u00celes Tuamotu-Gambier"
+    ],
+    "name:deu_x_variant":[
+        "Iles Tuamotu-Gambier"
     ],
     "name:ell_x_preferred":[
         "\u038a\u03bb\u03b5\u03c2 \u03a4\u03bf\u03c5\u03b1\u03bc\u03cc\u03c4\u03bf\u03c5-\u0393\u03ba\u03ac\u03bc\u03c0\u03b9\u03b5\u03c1"
@@ -54,10 +63,14 @@
         "Tuamotu-Gambier"
     ],
     "name:eng_x_variant":[
-        "\u00celes Tuamotu-Gambier"
+        "\u00celes Tuamotu-Gambier",
+        "Iles Tuamotu-Gambier"
     ],
     "name:fin_x_preferred":[
         "\u00celes Tuamotu-Gambier"
+    ],
+    "name:fin_x_variant":[
+        "Iles Tuamotu-Gambier"
     ],
     "name:fra_x_preferred":[
         "Archipels des Tuamotu et des Gambier"
@@ -65,7 +78,8 @@
     "name:fra_x_variant":[
         "Archipel des Tuamotu-Gambier",
         "Tuamotu-Gambier",
-        "\u00celes Tuamotu-Gambier"
+        "\u00celes Tuamotu-Gambier",
+        "\u00eeles Tuamotu-Gambier"
     ],
     "name:guj_x_preferred":[
         "\u0ab2\u0ac7\u0ab8 \u0aa4\u0ac1\u0a86\u0aae\u0acb\u0a9f\u0acb-\u0a97\u0ac5\u0aae\u0acd\u0aac\u0abf\u0a85\u0ab0"
@@ -78,6 +92,9 @@
     ],
     "name:ind_x_preferred":[
         "\u00celes Tuamotu-Gambier"
+    ],
+    "name:ind_x_variant":[
+        "Iles Tuamotu-Gambier"
     ],
     "name:ita_x_preferred":[
         "Isole Tuamotu-Gambier"
@@ -111,6 +128,9 @@
     ],
     "name:pol_x_preferred":[
         "\u00celes Tuamotu-Gambier"
+    ],
+    "name:pol_x_variant":[
+        "Iles Tuamotu-Gambier"
     ],
     "name:rus_x_preferred":[
         "\u0418\u043b\u044c \u0422\u044e\u0430\u043c\u043e\u0442\u044e-\u0413\u0430\u043c\u0431\u044c\u0435"
@@ -273,7 +293,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1636500407,
+    "wof:lastmodified":1690850814,
     "wof:name":"Tuamotu-Gambier",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/767/41/85676741.geojson
+++ b/data/856/767/41/85676741.geojson
@@ -35,6 +35,9 @@
     "name:ara_x_preferred":[
         "\u062c\u0632\u0631 \u0623\u0648\u0633\u062a\u0631\u0627\u0644"
     ],
+    "name:ast_x_preferred":[
+        "Islles Australes"
+    ],
     "name:bel_x_preferred":[
         "\u0410\u0441\u0442\u0440\u0430\u0432\u044b \u0422\u0443\u0431\u0443\u0430\u0456"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:ces_x_preferred":[
         "Ji\u017en\u00ed souostrov\u00ed"
+    ],
+    "name:cym_x_preferred":[
+        "Ynysoedd Austral"
     ],
     "name:dan_x_preferred":[
         "Austral\u00f8erne"
@@ -150,6 +156,9 @@
     "name:pol_x_preferred":[
         "Wyspy Tubuai"
     ],
+    "name:pol_x_variant":[
+        "\u00celes Australes"
+    ],
     "name:por_x_preferred":[
         "Arquip\u00e9lago das Austrais"
     ],
@@ -173,6 +182,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb8\u0bcd\u0b9f\u0bcd\u0bb0\u0bbe\u0bb2\u0bcd \u0b87\u0bb8\u0bcd\u0bb2\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd\u0bb8\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b85\u0bb8\u0bcd\u0b9f\u0bcd\u0bb0\u0bbe\u0bb2\u0bcd  \u0b87\u0bb8\u0bcd\u0bb2\u0bbe\u0ba3\u0bcd\u0b9f\u0bcd\u0bb8\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c06\u0c38\u0c4d\u0c1f\u0c4d\u0c30\u0c32\u0c4d \u0c26\u0c40\u0c35\u0c41\u0c32\u0c41"
@@ -338,7 +350,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1636500407,
+    "wof:lastmodified":1690850814,
     "wof:name":"Austral Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",

--- a/data/856/767/45/85676745.geojson
+++ b/data/856/767/45/85676745.geojson
@@ -44,6 +44,9 @@
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b0\u09cd\u0995\u09c7\u09b8\u09be\u09b8 \u09a6\u09cd\u09ac\u09c0\u09aa\u09aa\u09c1\u099e\u09cd\u099c"
     ],
+    "name:bos_x_preferred":[
+        "Markisko oto\u010dje"
+    ],
     "name:bre_x_preferred":[
         "Inizi Markiz"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:ces_x_preferred":[
         "Mark\u00e9zy"
+    ],
+    "name:chv_x_preferred":[
+        "\u041c\u0430\u0440\u043a\u0438\u0437 \u0443\u0442\u0440\u0430\u0432\u0115\u0441\u0435\u043c"
     ],
     "name:cym_x_preferred":[
         "Ynysoedd Marquesas"
@@ -98,6 +104,9 @@
     "name:fra_x_variant":[
         "\u00eeles Marquises"
     ],
+    "name:frr_x_preferred":[
+        "Marquesas-Eilunen"
+    ],
     "name:gla_x_preferred":[
         "Na Marquesas"
     ],
@@ -133,6 +142,9 @@
     ],
     "name:ita_x_preferred":[
         "Isole Marchesi"
+    ],
+    "name:ita_x_variant":[
+        "isole Marchesi"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30eb\u30ad\u30fc\u30ba\u8af8\u5cf6"
@@ -188,6 +200,9 @@
     "name:oci_x_preferred":[
         "Illas Marquesas"
     ],
+    "name:oci_x_variant":[
+        "illas Marquesas"
+    ],
     "name:pol_x_preferred":[
         "Markizy"
     ],
@@ -211,6 +226,12 @@
     ],
     "name:spa_x_preferred":[
         "Islas Marquesas"
+    ],
+    "name:spa_x_variant":[
+        "islas Marquesas"
+    ],
+    "name:srd_x_preferred":[
+        "\u00ccsulas Marchesas"
     ],
     "name:srp_x_preferred":[
         "\u041e\u0441\u0442\u0440\u0432\u0430 \u041c\u0430\u0440\u043a\u0438\u0437"
@@ -256,6 +277,9 @@
     ],
     "name:war_x_preferred":[
         "Kapuropod-an Marquises"
+    ],
+    "name:wuu_x_preferred":[
+        "\u9a6c\u514b\u8428\u65af\u7fa4\u5c9b"
     ],
     "name:yue_x_preferred":[
         "\u4faf\u7235\u592b\u4eba\u7fa4\u5cf6"
@@ -388,7 +412,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1636500406,
+    "wof:lastmodified":1690850813,
     "wof:name":"Marquesas Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",

--- a/data/890/425/731/890425731.geojson
+++ b/data/890/425/731/890425731.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u062a\u0648\u0631\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Mataura"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09a4\u09be\u0989\u09b0\u09be"
     ],
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":890425731,
-    "wof:lastmodified":1636500407,
+    "wof:lastmodified":1690850819,
     "wof:name":"Mataura",
     "wof:parent_id":85676741,
     "wof:placetype":"locality",

--- a/data/890/437/225/890437225.geojson
+++ b/data/890/437/225/890437225.geojson
@@ -34,6 +34,12 @@
     "name:fra_x_preferred":[
         "Rikitea"
     ],
+    "name:hun_x_preferred":[
+        "Rikitea"
+    ],
+    "name:ind_x_preferred":[
+        "Rikitea"
+    ],
     "name:jpn_x_preferred":[
         "\u30ea\u30ad\u30c6\u30a2"
     ],
@@ -44,6 +50,9 @@
         "Rikitea"
     ],
     "name:nob_x_preferred":[
+        "Rikitea"
+    ],
+    "name:pol_x_preferred":[
         "Rikitea"
     ],
     "name:por_x_preferred":[
@@ -99,7 +108,7 @@
         }
     ],
     "wof:id":890437225,
-    "wof:lastmodified":1566677719,
+    "wof:lastmodified":1690850820,
     "wof:name":"Rikitea",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/437/249/890437249.geojson
+++ b/data/890/437/249/890437249.geojson
@@ -22,6 +22,9 @@
     "name:afr_x_preferred":[
         "Punaauia"
     ],
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0646\u0627\u0648\u064a\u0627"
+    ],
     "name:arg_x_preferred":[
         "Punaauia"
     ],
@@ -211,6 +214,9 @@
     "name:ron_x_preferred":[
         "Punaauia"
     ],
+    "name:rus_x_preferred":[
+        "\u041f\u0443\u043d\u0430\u0430\u0443\u0439\u044f"
+    ],
     "name:scn_x_preferred":[
         "Punaauia"
     ],
@@ -299,7 +305,7 @@
         }
     ],
     "wof:id":890437249,
-    "wof:lastmodified":1566677719,
+    "wof:lastmodified":1690850820,
     "wof:name":"Punaauia",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/890/437/251/890437251.geojson
+++ b/data/890/437/251/890437251.geojson
@@ -124,6 +124,9 @@
     "name:jam_x_preferred":[
         "Papara"
     ],
+    "name:jpn_x_preferred":[
+        "\u30d1\u30d1\u30e9"
+    ],
     "name:kab_x_preferred":[
         "Papara"
     ],
@@ -283,7 +286,7 @@
         }
     ],
     "wof:id":890437251,
-    "wof:lastmodified":1566677719,
+    "wof:lastmodified":1690850820,
     "wof:name":"Papao",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/437/253/890437253.geojson
+++ b/data/890/437/253/890437253.geojson
@@ -19,10 +19,28 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:bre_x_preferred":[
+        "Paopao"
+    ],
     "name:bul_x_preferred":[
         "\u041f\u0430\u043e\u043f\u0430\u043e"
     ],
+    "name:cat_x_preferred":[
+        "Paopao"
+    ],
     "name:ceb_x_preferred":[
+        "Paopao"
+    ],
+    "name:ces_x_preferred":[
+        "Paopao"
+    ],
+    "name:cos_x_preferred":[
+        "Paopao"
+    ],
+    "name:cym_x_preferred":[
+        "Paopao"
+    ],
+    "name:dan_x_preferred":[
         "Paopao"
     ],
     "name:deu_x_preferred":[
@@ -31,16 +49,85 @@
     "name:eng_x_preferred":[
         "Paopao"
     ],
+    "name:est_x_preferred":[
+        "Paopao"
+    ],
+    "name:fin_x_preferred":[
+        "Paopao"
+    ],
     "name:fra_x_preferred":[
+        "Paopao"
+    ],
+    "name:gle_x_preferred":[
+        "Paopao"
+    ],
+    "name:glg_x_preferred":[
+        "Paopao"
+    ],
+    "name:hrv_x_preferred":[
+        "Paopao"
+    ],
+    "name:hun_x_preferred":[
+        "Paopao"
+    ],
+    "name:ind_x_preferred":[
+        "Paopao"
+    ],
+    "name:ita_x_preferred":[
+        "Paopao"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d1\u30aa\u30d1\u30aa"
+    ],
+    "name:lav_x_preferred":[
+        "Paopao"
+    ],
+    "name:lit_x_preferred":[
+        "Paopao"
+    ],
+    "name:ltz_x_preferred":[
+        "Paopao"
+    ],
+    "name:nld_x_preferred":[
+        "Paopao"
+    ],
+    "name:nrm_x_preferred":[
+        "Paopao"
+    ],
+    "name:oci_x_preferred":[
         "Paopao"
     ],
     "name:pol_x_preferred":[
         "Paopao"
     ],
+    "name:por_x_preferred":[
+        "Paopao"
+    ],
+    "name:roh_x_preferred":[
+        "Paopao"
+    ],
+    "name:ron_x_preferred":[
+        "Paopao"
+    ],
     "name:rus_x_preferred":[
         "\u041f\u0430\u043e\u043f\u0430\u043e"
     ],
+    "name:slk_x_preferred":[
+        "Paopao"
+    ],
+    "name:slv_x_preferred":[
+        "Paopao"
+    ],
     "name:spa_x_preferred":[
+        "Paopao"
+    ],
+    "name:swe_x_preferred":[
+        "Paopao"
+    ],
+    "name:tah_x_preferred":[
+        "Paopao"
+    ],
+    "name:tur_x_preferred":[
         "Paopao"
     ],
     "name:zho_x_preferred":[
@@ -79,7 +166,7 @@
         }
     ],
     "wof:id":890437253,
-    "wof:lastmodified":1566677719,
+    "wof:lastmodified":1690850821,
     "wof:name":"Paopao",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/890/438/917/890438917.geojson
+++ b/data/890/438/917/890438917.geojson
@@ -22,6 +22,9 @@
     "name:afr_x_preferred":[
         "Faaa"
     ],
+    "name:ara_x_preferred":[
+        "\u0641\u0627"
+    ],
     "name:arg_x_preferred":[
         "Faaa"
     ],
@@ -66,6 +69,9 @@
     ],
     "name:eng_x_preferred":[
         "Faaa"
+    ],
+    "name:eng_x_variant":[
+        "Fa\u02bba\u02bb\u0101"
     ],
     "name:epo_x_preferred":[
         "Faaa"
@@ -238,6 +244,9 @@
     "name:srd_x_preferred":[
         "Faaa"
     ],
+    "name:srp_x_preferred":[
+        "\u0424\u0430\u0430\u0430"
+    ],
     "name:swa_x_preferred":[
         "Faaa"
     ],
@@ -312,7 +321,7 @@
         }
     ],
     "wof:id":890438917,
-    "wof:lastmodified":1566677720,
+    "wof:lastmodified":1690850821,
     "wof:name":"Faaa",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/890/438/921/890438921.geojson
+++ b/data/890/438/921/890438921.geojson
@@ -37,8 +37,14 @@
     "name:bre_x_preferred":[
         "Taravao"
     ],
+    "name:bul_x_preferred":[
+        "\u0410\u0444\u0430\u0445\u0438\u0442\u0438"
+    ],
     "name:cat_x_preferred":[
         "Taravao"
+    ],
+    "name:ceb_x_preferred":[
+        "Afaahiti"
     ],
     "name:ces_x_preferred":[
         "Taravao"
@@ -289,7 +295,7 @@
         }
     ],
     "wof:id":890438921,
-    "wof:lastmodified":1566677719,
+    "wof:lastmodified":1690850821,
     "wof:name":"Afaahiti",
     "wof:parent_id":85676727,
     "wof:placetype":"locality",

--- a/data/890/441/237/890441237.geojson
+++ b/data/890/441/237/890441237.geojson
@@ -52,6 +52,9 @@
     "name:hye_x_preferred":[
         "\u0531\u057f\u0578\u0582\u0578\u0576\u0561"
     ],
+    "name:ita_x_preferred":[
+        "Atuona"
+    ],
     "name:jpn_x_preferred":[
         "\u30a2\u30c4\u30aa\u30ca"
     ],
@@ -78,6 +81,9 @@
     ],
     "name:tah_x_preferred":[
         "Atuona"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0410\u0442\u0443\u043e\u043d\u0430"
     ],
     "name:und_x_variant":[
         "Atuana"
@@ -119,7 +125,7 @@
         }
     ],
     "wof:id":890441237,
-    "wof:lastmodified":1566677718,
+    "wof:lastmodified":1690850819,
     "wof:name":"Atuona",
     "wof:parent_id":85676745,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.