### PR TITLE
pf concordances, placetype local, and more

### DIFF
--- a/data/856/767/27/85676727.geojson
+++ b/data/856/767/27/85676727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098577,
-    "geom:area_square_m":1161552217.710919,
+    "geom:area_square_m":1161552842.683396,
     "geom:bbox":"-150.655263,-17.869073,-149.149119,-16.982192",
     "geom:latitude":-17.647506,
     "geom:longitude":-149.468093,
@@ -309,8 +309,9 @@
         "wd:id":"Q140298",
         "wk:page":"Windward Islands (Society Islands)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PF",
-    "wof:geomhash":"ca79142aa61305a15e87fa597e4a706c",
+    "wof:geomhash":"6071c17c2dbdf2593465e3011d803224",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -329,7 +330,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1690850813,
+    "wof:lastmodified":1695884865,
     "wof:name":"Windward Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",

--- a/data/856/767/31/85676731.geojson
+++ b/data/856/767/31/85676731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027688,
-    "geom:area_square_m":327850660.542161,
+    "geom:area_square_m":327851161.721454,
     "geom:bbox":"-154.536977,-16.902927,-150.978383,-15.789321",
     "geom:latitude":-16.742407,
     "geom:longitude":-151.468492,
@@ -282,8 +282,9 @@
         "wd:id":"Q1999082",
         "wk:page":"Leeward Islands (Society Islands)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PF",
-    "wof:geomhash":"36ce431ac8483e78222c03c7b7ad6616",
+    "wof:geomhash":"fe9159b0bcadc637ecc14ce4039a8bba",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -302,7 +303,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1690850813,
+    "wof:lastmodified":1695884865,
     "wof:name":"Leeward Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",

--- a/data/856/767/37/85676737.geojson
+++ b/data/856/767/37/85676737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056685,
-    "geom:area_square_m":667981645.892303,
+    "geom:area_square_m":667984034.080927,
     "geom:bbox":"-148.690663,-23.138767,-134.942983,-14.164972",
     "geom:latitude":-17.516895,
     "geom:longitude":-142.316726,
@@ -274,8 +274,9 @@
         "qs_pg:id":1263430,
         "wd:id":"Q3773321"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PF",
-    "wof:geomhash":"fec8854c5b7384db27029d3ec944dc4d",
+    "wof:geomhash":"7cb430e523e2020757f9c6ede68e4ee2",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -293,7 +294,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1690850814,
+    "wof:lastmodified":1695884865,
     "wof:name":"Tuamotu-Gambier",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/767/41/85676741.geojson
+++ b/data/856/767/41/85676741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010035,
-    "geom:area_square_m":112519067.018474,
+    "geom:area_square_m":112519103.401233,
     "geom:bbox":"-154.702667,-27.641209,-144.283762,-21.797703",
     "geom:latitude":-24.837553,
     "geom:longitude":-147.740817,
@@ -330,8 +330,9 @@
         "qs_pg:id":961383,
         "wd:id":"Q930426"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PF",
-    "wof:geomhash":"db63560ed87b16dffdb089573c511c33",
+    "wof:geomhash":"d6e305fefd14250b54a0504775d2716a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -350,7 +351,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1690850814,
+    "wof:lastmodified":1695884865,
     "wof:name":"Austral Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",

--- a/data/856/767/45/85676745.geojson
+++ b/data/856/767/45/85676745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088444,
-    "geom:area_square_m":1078953325.002033,
+    "geom:area_square_m":1078953262.933425,
     "geom:bbox":"-140.727773,-10.55047,-138.620229,-7.950128",
     "geom:latitude":-9.377794,
     "geom:longitude":-139.573269,
@@ -392,8 +392,9 @@
         "qs_pg:id":1085967,
         "wd:id":"Q172697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PF",
-    "wof:geomhash":"4dcc27448d6cf6b61ea706ec774c4a51",
+    "wof:geomhash":"83e253cd20685cdb6008cbac482d4f54",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -412,7 +413,7 @@
         "fra",
         "tah"
     ],
-    "wof:lastmodified":1690850813,
+    "wof:lastmodified":1695884865,
     "wof:name":"Marquesas Islands",
     "wof:parent_id":85632653,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.